### PR TITLE
Add versions() method to get lib version info

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Michal Krenek (Mikos) <m.krenek@gmail.com>
 pkgname=simplesoapy
 _pkgname=simplesoapy
-pkgver=1.5.1
+pkgver=1.5.2
 pkgrel=1
 pkgdesc="Simple pythonic wrapper for SoapySDR library"
 arch=('any')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="SimpleSoapy",
-    version="1.5.1",
+    version="1.5.2",
     description="Simple pythonic wrapper for SoapySDR library",
     long_description=open("README.rst").read(),
     author="Michal Krenek (Mikos)",

--- a/simplesoapy.py
+++ b/simplesoapy.py
@@ -5,9 +5,19 @@ import sys, math, logging, collections, collections.abc, itertools
 import SoapySDR
 import numpy
 
-__version__ = '1.5.1'
+__version__ = '1.5.2'
 logger = logging.getLogger(__name__)
 
+def versions():
+    """Return an array of loaded SoapySDR library version strings"""
+    versions_str = []
+    versions_str.append('simplesoapy {}'.format(__version__))
+    versions_str.append('SoapySDR {}'.format(SoapySDR.getLibVersion()))
+    for module in SoapySDR.listModules():
+        modver = SoapySDR.getModuleVersion(module)
+        if modver:
+            versions_str.append('{} {}'.format(module.split('/')[-1], modver))
+    return versions_str
 
 def closest(num_list, num):
     """Return number closest to supplied number from list of numbers"""


### PR DESCRIPTION
This PR provides a method to get the version of the loaded SoapySDR libraries from python.